### PR TITLE
Replace hardcoded ints with AnimationID

### DIFF
--- a/src/main/java/com/truetileanimationmovement/AnimationRequestMoveset.java
+++ b/src/main/java/com/truetileanimationmovement/AnimationRequestMoveset.java
@@ -2,6 +2,8 @@ package com.truetileanimationmovement;
 
 import java.lang.reflect.Array;
 
+import net.runelite.api.gameval.AnimationID;
+
 public class AnimationRequestMoveset
 {
 // Juicy animations
@@ -197,7 +199,7 @@ public class AnimationRequestMoveset
             Initialize();
 
             // SOUTHEAST_2;
-            SOUTHEAST_2.AnimationToPlay = 1770; // lean WAY back
+            SOUTHEAST_2.AnimationToPlay = AnimationID.MDAUGHTER_ABSAIL_JUMP; // lean WAY back. 1770
             SOUTHEAST_2.bUseLinearTween = false;
             SOUTHEAST_2.MovementSpeedMultiplier = 1.5;
             SOUTHEAST_2.AnimationSpeed = 1;
@@ -205,7 +207,7 @@ public class AnimationRequestMoveset
 
 
             // SOUTHSOUTHWEST;
-            SOUTHWESTWEST.AnimationToPlay = 1764; // sick jump land
+            SOUTHWESTWEST.AnimationToPlay = AnimationID.MDAUGHTER_TREE_CLIMB3; // sick jump land. 1764
             SOUTHWESTWEST.bUseLinearTween = false;
             SOUTHWESTWEST.MovementSpeedMultiplier = 1.5;
             SOUTHWESTWEST.AnimationSpeed = 1;
@@ -213,20 +215,20 @@ public class AnimationRequestMoveset
 
 
             // WEST_2;
-            WEST_2.AnimationToPlay = 2107; // Side step 2, spin emote
+            WEST_2.AnimationToPlay = AnimationID.EMOTE_DANCE_SPIN; // Side step 2, spin emote. 2107
             WEST_2.MovementSpeedMultiplier = 2;
             WEST_2.AnimationSpeed = 1;
             WEST_2.StartingFrame = 4;
 
             // NORTHWESTWEST;
-            NORTHWESTWEST.AnimationToPlay = 409; // another cool spin move
+            NORTHWESTWEST.AnimationToPlay = AnimationID.HUMAN_DHSWORD_SPIN; // another cool spin move. 409
             NORTHWESTWEST.MovementSpeedMultiplier = 2;
             NORTHWESTWEST.AnimationSpeed = 1;
             NORTHWESTWEST.StartingFrame = 0;
 
 
             // NORTHEAST_2;
-            NORTHEAST_2.AnimationToPlay = 1852; // huge jump land
+            NORTHEAST_2.AnimationToPlay = AnimationID.DWARFROCK_CANNON_FLY_GETUP; // huge jump land. 1852
             NORTHEAST_2.bUseLinearTween = false;
             NORTHEAST_2.MovementSpeedMultiplier = 1.5;
             NORTHEAST_2.AnimationSpeed = 1;
@@ -234,7 +236,7 @@ public class AnimationRequestMoveset
 
 
             // SOUTHSOUTHEAST;
-            SOUTHSOUTHEAST.AnimationToPlay = 1764; // sick jump land
+            SOUTHSOUTHEAST.AnimationToPlay = AnimationID.MDAUGHTER_TREE_CLIMB3; // sick jump land. 1764
             SOUTHSOUTHEAST.bUseLinearTween = false;
             SOUTHSOUTHEAST.MovementSpeedMultiplier = 1.5;
             SOUTHSOUTHEAST.AnimationSpeed = 1;
@@ -242,41 +244,41 @@ public class AnimationRequestMoveset
 
 
             // SOUTHWEST_1;
-            SOUTHWEST_1.AnimationToPlay = 1702; // side step small
+            SOUTHWEST_1.AnimationToPlay = AnimationID.HUMAN_ZAMORAKSPEAR_TURNONSPOT; // side step small. 1702
             SOUTHWEST_1.bUseLinearTween = true;
             SOUTHWEST_1.MovementSpeedMultiplier = 1.0;
             SOUTHWEST_1.AnimationSpeed = 1;
             SOUTHWEST_1.StartingFrame = 0;
 
             // WEST_1;
-            WEST_1.AnimationToPlay = 821; // SIDE STEP LEFT
+            WEST_1.AnimationToPlay = AnimationID.HUMAN_WALK_L; // SIDE STEP LEFT. 821
             WEST_1.MovementSpeedMultiplier = 1.5;
             WEST_1.AnimationSpeed = 2;
             WEST_1.StartingFrame = 0;
 
             // NORTHWEST_1;
-            NORTHWEST_1.AnimationToPlay = 807; // Small hop
+            NORTHWEST_1.AnimationToPlay = AnimationID.HUMAN_LONGJUMP; // Small hop. 807
             NORTHWEST_1.MovementSpeedMultiplier = 3.0;
             NORTHWEST_1.StartingFrame = 7;
             NORTHWEST_1.AnimationSpeed = 1;
 
 
             // NORTHNORTHEAST;
-            NORTHNORTHEAST.AnimationToPlay = 2750; // Super far jump forward
+            NORTHNORTHEAST.AnimationToPlay = AnimationID.OVERLOG; // Super far jump forward. 2750
             NORTHNORTHEAST.bUseLinearTween = false;
             NORTHNORTHEAST.MovementSpeedMultiplier = 1.6;
             NORTHNORTHEAST.AnimationSpeed = 2;
             NORTHNORTHEAST.StartingFrame = 2;
 
             // BACK_2;
-            BACK_2.AnimationToPlay = 2390; // big knockback
+            BACK_2.AnimationToPlay = AnimationID.TBW_CLEANUP_PLAYER_SURPRISE_STEPBACK; // big knockback. 2390
             BACK_2.bUseLinearTween = false;
             BACK_2.MovementSpeedMultiplier = 2;
             BACK_2.AnimationSpeed = 1;
             BACK_2.StartingFrame = 0;
 
             // BACK_1;
-            BACK_1.AnimationToPlay = 1441; // knockback
+            BACK_1.AnimationToPlay = AnimationID.HUMAN_STUMBLE_BACK_CONTINUOUS; // knockback. 1441
             BACK_1.bUseLinearTween = true;
             BACK_1.MovementSpeedMultiplier = 1;
             BACK_1.AnimationSpeed = 1;
@@ -284,19 +286,19 @@ public class AnimationRequestMoveset
 
             CENTER.AnimationToPlay = AnimSet.IdleRotateRight; // Center
 
-            FORWARD_1.AnimationToPlay = 7515; // Jab forward
+            FORWARD_1.AnimationToPlay = AnimationID.HUMAN_DRAGON_SWORD_SPEC; // Jab forward. 7515
             FORWARD_1.MovementSpeedMultiplier = 2.0;
             FORWARD_1.StartingFrame = 0;
             FORWARD_1.AnimationSpeed = 1;
 
             // FORWARD_2;
-            FORWARD_2.AnimationToPlay = 3067; // Big jump forward
+            FORWARD_2.AnimationToPlay = AnimationID.AGILITY_PYRAMID_GAP_JUMP; // Big jump forward. 3067
             FORWARD_2.MovementSpeedMultiplier = 2;
             FORWARD_2.AnimationSpeed = 2;
             FORWARD_2.StartingFrame = 2;
 
             // SOUTHWESTWEST;
-            SOUTHSOUTHWEST.AnimationToPlay = 870; // Jumping Jack
+            SOUTHSOUTHWEST.AnimationToPlay = AnimationID.EMOTE_STARJUMP_5; // Jumping Jack. 870
             SOUTHSOUTHWEST.bUseLinearTween = false;
             SOUTHSOUTHWEST.MovementSpeedMultiplier = 2;
             SOUTHSOUTHWEST.AnimationSpeed = 1;
@@ -304,7 +306,7 @@ public class AnimationRequestMoveset
 
 
             // SOUTHEAST_1;
-            SOUTHEAST_1.AnimationToPlay = 1702; // side step small
+            SOUTHEAST_1.AnimationToPlay = AnimationID.HUMAN_ZAMORAKSPEAR_TURNONSPOT; // side step small. 1702
             SOUTHEAST_1.bUseLinearTween = true;
             SOUTHEAST_1.MovementSpeedMultiplier = 1.0;
             SOUTHEAST_1.AnimationSpeed = 1;
@@ -312,52 +314,52 @@ public class AnimationRequestMoveset
 
 
             // EAST_2;
-            EAST_1.AnimationToPlay = 822; // SIDE STEP RIGHT
+            EAST_1.AnimationToPlay = AnimationID.HUMAN_WALK_R; // SIDE STEP RIGHT. 822
             EAST_1.MovementSpeedMultiplier = 1.5;
             EAST_1.AnimationSpeed = 2;
 
             // NORTHEAST_1;
-            NORTHEAST_1.AnimationToPlay = 807; // North-east
+            NORTHEAST_1.AnimationToPlay = AnimationID.HUMAN_LONGJUMP; // North-east. 807
             NORTHEAST_1.MovementSpeedMultiplier = 3.0;
             NORTHEAST_1.StartingFrame = 7;
             NORTHEAST_1.AnimationSpeed = 1;
 
             // NORTHNORTHWEST;
-            NORTHNORTHWEST.AnimationToPlay = 2750; // Super far jump forward
+            NORTHNORTHWEST.AnimationToPlay = AnimationID.OVERLOG; // Super far jump forward. 2750
             NORTHNORTHWEST.bUseLinearTween = false;
             NORTHNORTHWEST.MovementSpeedMultiplier = 1.6;
             NORTHNORTHWEST.AnimationSpeed = 2;
             NORTHNORTHWEST.StartingFrame = 2;
 
             // SOUTHWEST_2;
-            SOUTHWEST_2.AnimationToPlay = 1770; // lean WAY back
+            SOUTHWEST_2.AnimationToPlay = AnimationID.MDAUGHTER_ABSAIL_JUMP; // lean WAY back. 1770
             SOUTHWEST_2.bUseLinearTween = false;
             SOUTHWEST_2.MovementSpeedMultiplier = 1.5;
             SOUTHWEST_2.AnimationSpeed = 1;
             SOUTHWEST_2.StartingFrame = 0;
 
             // SOUTHEASTEAST;
-            SOUTHEASTEAST.AnimationToPlay = 870; // Jumping Jack
+            SOUTHEASTEAST.AnimationToPlay = AnimationID.EMOTE_STARJUMP_5; // Jumping Jack. 870
             SOUTHEASTEAST.bUseLinearTween = false;
             SOUTHEASTEAST.MovementSpeedMultiplier = 2;
             SOUTHEASTEAST.AnimationSpeed = 1;
             SOUTHEASTEAST.StartingFrame = 0;
 
             // EAST_2
-            EAST_2.AnimationToPlay = 2107; // SIDE_STEP 2 - spin emote
+            EAST_2.AnimationToPlay = AnimationID.EMOTE_DANCE_SPIN; // SIDE_STEP 2 - spin emote. 2107
             EAST_2.MovementSpeedMultiplier = 2;
             EAST_2.AnimationSpeed = 1;
             EAST_2.StartingFrame = 4;
 
             // NORTHEASTEAST;
-            NORTHEASTEAST.AnimationToPlay = 409; // another cool spin move
+            NORTHEASTEAST.AnimationToPlay = AnimationID.HUMAN_DHSWORD_SPIN; // another cool spin move. 409
             NORTHEASTEAST.MovementSpeedMultiplier = 2;
             NORTHEASTEAST.AnimationSpeed = 1;
             NORTHEASTEAST.StartingFrame = 0;
 
 
             // NORTHWEST_2;
-            NORTHWEST_2.AnimationToPlay = 1852; // huge jump land
+            NORTHWEST_2.AnimationToPlay = AnimationID.DWARFROCK_CANNON_FLY_GETUP; // huge jump land. 1852
             NORTHWEST_2.bUseLinearTween = false;
             NORTHWEST_2.MovementSpeedMultiplier = 1.5;
             NORTHWEST_2.AnimationSpeed = 1;
@@ -375,7 +377,7 @@ public class AnimationRequestMoveset
                     if (i == 0 || j == 0 || i == 4 || j == 4)
                     {
                         MovesetArray[i][j].bResetAnimationOnNewTile = true;
-                        MovesetArray[i][j].AnimationToPlay = 1604;
+                        MovesetArray[i][j].AnimationToPlay = AnimationID.HUMAN_JUMP_STONES; // 1604
                         MovesetArray[i][j].bUseLinearTween = false;
                         MovesetArray[i][j].MovementSpeedMultiplier = 1.5;
                         MovesetArray[i][j].AnimationSpeed = 1;
@@ -384,7 +386,7 @@ public class AnimationRequestMoveset
                     // 1 Tile
                     else if (i == 1 || j == 1 || i == 3 || j == 3)
                     {
-                        MovesetArray[i][j].AnimationToPlay = 741; // Little jump
+                        MovesetArray[i][j].AnimationToPlay = AnimationID.HUMAN_SPOT_JUMP; // Little jump. 741
                         MovesetArray[i][j].MovementSpeedMultiplier = 2.0;
                         MovesetArray[i][j].bUseLinearTween = false;
                         MovesetArray[i][j].StartingFrame = 2;
@@ -406,7 +408,7 @@ public class AnimationRequestMoveset
                     if (i == 0 || j == 0 || i == 4 || j == 4)
                     {
                         MovesetArray[i][j].bResetAnimationOnNewTile = true;
-                        MovesetArray[i][j].AnimationToPlay = 1604;
+                        MovesetArray[i][j].AnimationToPlay = AnimationID.HUMAN_JUMP_STONES; // 1604
                         MovesetArray[i][j].bUseLinearTween = false;
                         MovesetArray[i][j].MovementSpeedMultiplier = 1.5;
                         MovesetArray[i][j].AnimationSpeed = 1;
@@ -415,7 +417,7 @@ public class AnimationRequestMoveset
                     // 1 Tile
                     else if (i == 1 || j == 1 || i == 3 || j == 3)
                     {
-                        MovesetArray[i][j].AnimationToPlay = 741; // Little jump
+                        MovesetArray[i][j].AnimationToPlay = AnimationID.HUMAN_SPOT_JUMP; // Little jump. 741
                         MovesetArray[i][j].MovementSpeedMultiplier = 2.0;
                         MovesetArray[i][j].bUseLinearTween = false;
                         MovesetArray[i][j].StartingFrame = 2;

--- a/src/main/java/com/truetileanimationmovement/CustomMovementHandler.java
+++ b/src/main/java/com/truetileanimationmovement/CustomMovementHandler.java
@@ -3,6 +3,7 @@ package com.truetileanimationmovement;
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.client.config.ConfigItem;
 
 import javax.inject.Inject;
@@ -101,40 +102,40 @@ public class CustomMovementHandler
         this.Owner = Owner;
 
         // Initialize all animations we do want to lerp
-        UniqueAnimationExceptionList.add(2588); // Agility
-        UniqueAnimationExceptionList.add(2586); // Agility
-        UniqueAnimationExceptionList.add(2583); // Agility
-        UniqueAnimationExceptionList.add(714); // Teleport
-        UniqueAnimationExceptionList.add(878); // Teleport
-        UniqueAnimationExceptionList.add(1816); // Teleport
-        UniqueAnimationExceptionList.add(1979); // Teleport
-        UniqueAnimationExceptionList.add(3872); // Teleport
-        UniqueAnimationExceptionList.add(13811); // Teleport
-        UniqueAnimationExceptionList.add(4069); // Teleport
-        UniqueAnimationExceptionList.add(4071); // Teleport
-        UniqueAnimationExceptionList.add(3869); // Teleport
-        UniqueAnimationExceptionList.add(3865); // Teleport
-        UniqueAnimationExceptionList.add(2881); // Teleport
+        UniqueAnimationExceptionList.add(AnimationID.AGILITY_SHORTCUT_WALL_JUMPDOWN2); // Agility. 2588
+        UniqueAnimationExceptionList.add(AnimationID.AGILITY_SHORTCUT_WALL_JUMPDOWN); // Agility. 2586
+        UniqueAnimationExceptionList.add(AnimationID.AGILITY_SHORTCUT_WALL_JUMP); // Agility. 2583
+        UniqueAnimationExceptionList.add(AnimationID.HUMAN_CASTTELEPORT); // Teleport. 714
+        UniqueAnimationExceptionList.add(AnimationID.AHOY_ECTO_TELEPORT); // Teleport. 878
+        UniqueAnimationExceptionList.add(AnimationID.HUMAN_TELEPORT_OTHER_IMPACT); // Teleport. 1816
+        UniqueAnimationExceptionList.add(AnimationID.ZAROS_VERTICAL_CASTING); // Teleport. 1979
+        UniqueAnimationExceptionList.add(AnimationID.TELEPORT_NARDAH_HUMAN); // Teleport. 3872
+        UniqueAnimationExceptionList.add(AnimationID.HUMAN_COWBOSS_TELEPORT); // Teleport. 13811
+        UniqueAnimationExceptionList.add(AnimationID.POH_SMASH_MAGIC_TABLET); // Teleport. 4069
+        UniqueAnimationExceptionList.add(AnimationID.POH_ABSORB_TABLET_TELEPORT); // Teleport. 4071
+        UniqueAnimationExceptionList.add(AnimationID.TELEPORT_CABBAGE_HUMAN); // Teleport. 3869
+        UniqueAnimationExceptionList.add(AnimationID.ARCEUUS_NECROMANCY_ANIM); // Teleport. 3865
+        UniqueAnimationExceptionList.add(AnimationID.NTK_HUMAN_TELE); // Teleport. 2881
 
-        UniqueAnimationLocationAndOrientationExceptionList.add(749); // crawl pipe
-        UniqueAnimationLocationAndOrientationExceptionList.add(751); // rope swing
-        UniqueAnimationLocationAndOrientationExceptionList.add(840); // climb over
-        UniqueAnimationLocationAndOrientationExceptionList.add(839); // climb over
-        UniqueAnimationLocationAndOrientationExceptionList.add(1252); // climb over
-        UniqueAnimationLocationAndOrientationExceptionList.add(828); // climb up
-        UniqueAnimationLocationAndOrientationExceptionList.add(740); // climb up
-        UniqueAnimationLocationAndOrientationExceptionList.add(7134); // slide down
-        UniqueAnimationLocationAndOrientationExceptionList.add(844); // crawl
-        UniqueAnimationLocationAndOrientationExceptionList.add(769); // long hop
-        UniqueAnimationLocationAndOrientationExceptionList.add(3057); // Wall climb
-        UniqueAnimationLocationAndOrientationExceptionList.add(3058); // Wall climb
-        UniqueAnimationLocationAndOrientationExceptionList.add(3067); // long jump
-        UniqueAnimationLocationAndOrientationExceptionList.add(3068); // long jump
-        UniqueAnimationLocationAndOrientationExceptionList.add(1115); // jump and cover
-        UniqueAnimationLocationAndOrientationExceptionList.add(5708); // penguin
-        UniqueAnimationLocationAndOrientationExceptionList.add(5709); // penguin
-        UniqueAnimationLocationAndOrientationExceptionList.add(3844); // fence shuffle
-        UniqueAnimationLocationAndOrientationExceptionList.add(1237); // tir obstacles
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_DOUBLEPIPESQUEEZE); // crawl pipe. 749
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_ROPESWING_LONG); // rope swing. 751
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_WALK_CRUMBLEDWALL); // climb over. 840
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_WALK_STYLE); // climb over. 839
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_LOWWALL); // climb over. 1252
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_REACHFORLADDER); // climb up. 828
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_CLIMBING_DOWN); // climb up. 740
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_WALK_LOGBALANCE_LOOP); // slide down. 7134
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_CRAWLING); // crawl. 844
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.HUMAN_STEPPINGSTONEJUMP); // long hop. 769
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.AGILITY_PYRAMID_LEDGE_ON_RIGHT); // Wall climb. 3057
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.AGILITY_PYRAMID_LEDGE_OFF_RIGHT); // Wall climb. 3058
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.AGILITY_PYRAMID_GAP_JUMP); // long jump. 3067
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.AGILITY_PYRAMID_GAP_JUMP_FALL); // long jump. 3068
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.AGILITYARENA_DIVE_PLAYER); // jump and cover. 1115
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.PENG_JUMP_A); // penguin. 5708
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.PENG_JUMP_B); // penguin. 5709
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.RAILING_SQUEEZE); // fence shuffle. 3844
+        UniqueAnimationLocationAndOrientationExceptionList.add(AnimationID.REGICIDE_TIGHTFIT); // tir obstacles. 1237
     }
 
     double quadraticTween(long startTime, long endTime, long currentTime)
@@ -402,10 +403,11 @@ public class CustomMovementHandler
             OldAnimationHeight = Owner.getAnimationHeightOffset();
 
             // Monkey or penguin
-            if (OldAnimationSet.IdlePoseAnimation == 1386 ||
-                    OldAnimationSet.IdlePoseAnimation == 222 ||
-                    OldAnimationSet.IdlePoseAnimation == 1401 ||
-                    OldAnimationSet.IdlePoseAnimation == 5668)
+            // 1386, 222, 1401, 5668
+            if (OldAnimationSet.IdlePoseAnimation == AnimationID.M_MONKEY_READY ||
+                    OldAnimationSet.IdlePoseAnimation == AnimationID.MONKEY_READY ||
+                    OldAnimationSet.IdlePoseAnimation == AnimationID.M_GORILLA_READY ||
+                    OldAnimationSet.IdlePoseAnimation == AnimationID.PENG_GENTOO_READY)
             {
                 bIsDefaultHumanAnimationSet = false;
             }
@@ -824,7 +826,7 @@ public class CustomMovementHandler
                     else
                     {
                         CurrentAnimationRequest.bShouldTeleportToLocation = true;
-                        CurrentAnimationRequest.AnimationToPlay = 715; // Teleport in
+                        CurrentAnimationRequest.AnimationToPlay = AnimationID.HUMAN_CASTTELEPORT_REVERSE; // Teleport in. 715
 
                         ChangeLastLerpPointForRotation();
                     }
@@ -908,22 +910,22 @@ public class CustomMovementHandler
             if (LastNPCCombatLevel > 300)
             {
                 // 2,387->Fist pump
-                CurrentAnimationRequest.AnimationToPlay = 2106; // Jig
+                CurrentAnimationRequest.AnimationToPlay = AnimationID.EMOTE_DANCE_SCOTTISH; // Jig. 2106
             }
             else if (LastNPCCombatLevel > 200)
             {
                 // 2,387->Fist pump
-                CurrentAnimationRequest.AnimationToPlay = 866; // Dance
+                CurrentAnimationRequest.AnimationToPlay = AnimationID.EMOTE_DANCE; // Dance. 866
             }
             else if (LastNPCCombatLevel > 150)
             {
                 // 2,387->Fist pump
-                CurrentAnimationRequest.AnimationToPlay = 8917; // Flex
+                CurrentAnimationRequest.AnimationToPlay = AnimationID.EMOTE_FLEX; // Flex. 8917
             }
             else if (LastNPCCombatLevel > 100)
             {
                 // 2,387->Fist pump
-                CurrentAnimationRequest.AnimationToPlay = 862; // Cheer
+                CurrentAnimationRequest.AnimationToPlay = AnimationID.EMOTE_CHEER; // Cheer. 862
             }
             // > 50
             else

--- a/src/main/java/com/truetileanimationmovement/TrueTileMovementPlugin.java
+++ b/src/main/java/com/truetileanimationmovement/TrueTileMovementPlugin.java
@@ -8,6 +8,7 @@ import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.*;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.api.gameval.VarClientID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
@@ -591,17 +592,17 @@ public class TrueTileMovementPlugin extends Plugin
 		}
 
 		// Teleports
-		if (client.getLocalPlayer().getAnimation() == 714 ||
-				client.getLocalPlayer().getAnimation() == 878 ||
-				client.getLocalPlayer().getAnimation() == 1816 ||
-				client.getLocalPlayer().getAnimation() == 1979 ||
-				client.getLocalPlayer().getAnimation() == 3872 ||
-				client.getLocalPlayer().getAnimation() == 13811 ||
-				client.getLocalPlayer().getAnimation() == 4069 ||
-				client.getLocalPlayer().getAnimation() == 4071 ||
-				client.getLocalPlayer().getAnimation() == 3869 ||
-				client.getLocalPlayer().getAnimation() == 3865 ||
-				client.getLocalPlayer().getAnimation() == 2881
+		if (client.getLocalPlayer().getAnimation() == AnimationID.HUMAN_CASTTELEPORT || // 714
+				client.getLocalPlayer().getAnimation() == AnimationID.AHOY_ECTO_TELEPORT || // 878
+				client.getLocalPlayer().getAnimation() == AnimationID.HUMAN_TELEPORT_OTHER_IMPACT || // 1816
+				client.getLocalPlayer().getAnimation() == AnimationID.ZAROS_VERTICAL_CASTING || // 1979
+				client.getLocalPlayer().getAnimation() == AnimationID.TELEPORT_NARDAH_HUMAN || // 3872
+				client.getLocalPlayer().getAnimation() == AnimationID.HUMAN_COWBOSS_TELEPORT || // 13811
+				client.getLocalPlayer().getAnimation() == AnimationID.POH_SMASH_MAGIC_TABLET || // 4069
+				client.getLocalPlayer().getAnimation() == AnimationID.POH_ABSORB_TABLET_TELEPORT || // 4071
+				client.getLocalPlayer().getAnimation() == AnimationID.TELEPORT_CABBAGE_HUMAN || // 3869
+				client.getLocalPlayer().getAnimation() == AnimationID.ARCEUUS_NECROMANCY_ANIM || // 3865
+				client.getLocalPlayer().getAnimation() == AnimationID.NTK_HUMAN_TELE // 2881
 		)
 		{
 			OverlayRenderer.LastTimeTeleport = System.currentTimeMillis();


### PR DESCRIPTION
Use AnimationID in place of hardcoded integer values.

Retained original integer values as inline comments to build confidence. AnimationID has been used in the 3 classes for easier readability and maintenance.

Each mapping has been reviewed before submission.