### PR TITLE
Small improvements to AnimationRequestMovesetCache

### DIFF
--- a/src/main/java/com/truetileanimationmovement/AnimationRequestMovesetCache.java
+++ b/src/main/java/com/truetileanimationmovement/AnimationRequestMovesetCache.java
@@ -5,40 +5,44 @@ import java.util.Map;
 
 public class AnimationRequestMovesetCache
 {
-    static public Map<String, AnimationRequestMoveset> NameToMovesetRequest = new HashMap<>();
-    static public AnimationRequestMoveset GetAnimationRequestMovesetFromUniqueKey(IdleAnimationSet AnimSet, String UniqueLabel, TrueTileMovementConfig config)
+    private static final Map<String, AnimationRequestMoveset>
+            NAME_TO_MOVESET_REQUEST = new HashMap<>();
+
+    private AnimationRequestMovesetCache()
+    {
+    }
+
+    public static AnimationRequestMoveset getMovesetFromUniqueKey(
+            final IdleAnimationSet animSet,
+            final String uniqueLabel,
+            final TrueTileMovementConfig config)
     {
         // TODO: BUG->Config not effecting Label, so changes to the config does not update this
-        if (NameToMovesetRequest.containsKey(UniqueLabel))
+        return NAME_TO_MOVESET_REQUEST.computeIfAbsent(uniqueLabel, key ->
         {
-            return NameToMovesetRequest.get(UniqueLabel);
-        }
-
-        AnimationRequestMoveset NewMoveset = new AnimationRequestMoveset();
-        NewMoveset.Initialize();
-
-        NewMoveset.ConstructFromSpecialAnimationSet(AnimSet, UniqueLabel, config);
-
-        NameToMovesetRequest.put(UniqueLabel, NewMoveset);
-
-        return NewMoveset;
+            final AnimationRequestMoveset newMoveset =
+                    new AnimationRequestMoveset();
+            newMoveset.Initialize();
+            newMoveset.ConstructFromSpecialAnimationSet(
+                    animSet, uniqueLabel, config);
+            return newMoveset;
+        });
     }
-    static public AnimationRequestMoveset GetAnimationRequestMovesetFromAnimationSet(IdleAnimationSet AnimSet, TrueTileMovementConfig config)
+
+    public static AnimationRequestMoveset getMovesetFromAnimationSet(
+            final IdleAnimationSet animSet,
+            final TrueTileMovementConfig config)
     {
         // Have the label encode a unique String for all config options that can mess with it
-        String UniqueLabel = AnimSet.GetUniqueLabel() + config.OrientationRotationSpeed();
-        if (NameToMovesetRequest.containsKey(UniqueLabel))
+        final String uniqueLabel =
+                animSet.GetUniqueLabel() + config.OrientationRotationSpeed();
+        return NAME_TO_MOVESET_REQUEST.computeIfAbsent(uniqueLabel, key ->
         {
-            return NameToMovesetRequest.get(UniqueLabel);
-        }
-
-        AnimationRequestMoveset NewMoveset = new AnimationRequestMoveset();
-        NewMoveset.Initialize();
-
-        NewMoveset.ConstructFromIdleAnimationSet(AnimSet, config);
-
-        NameToMovesetRequest.put(UniqueLabel, NewMoveset);
-
-        return NewMoveset;
+            final AnimationRequestMoveset newMoveset =
+                    new AnimationRequestMoveset();
+            newMoveset.Initialize();
+            newMoveset.ConstructFromIdleAnimationSet(animSet, config);
+            return newMoveset;
+        });
     }
 }

--- a/src/main/java/com/truetileanimationmovement/CustomMovementHandler.java
+++ b/src/main/java/com/truetileanimationmovement/CustomMovementHandler.java
@@ -818,7 +818,7 @@ public class CustomMovementHandler
                     if (CurrentTime - overlay.LastTimeTeleport < 600) // Blend with the first tick
                     {
                         // Handle normal walking
-                        CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.GetAnimationRequestMovesetFromAnimationSet(OldAnimationSet, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                        CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromAnimationSet(OldAnimationSet, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
                         CurrentAnimationRequest.bShouldTeleportToLocation = false;
                     }
                     else
@@ -852,7 +852,7 @@ public class CustomMovementHandler
                         int TempRotatedDirectionX = Math.max(-2, Math.min(2, Math.toIntExact(Math.round((DirectionX * cos - DirectionY * sin) / 128.0))));
                         int TempRotatedDirectionY = Math.max(-2, Math.min(2, Math.toIntExact(Math.round((DirectionX * sin + DirectionY * cos) / 128.0))));
 
-                        CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.GetAnimationRequestMovesetFromAnimationSet(OldAnimationSet, config).MovesetArray[2 + TempRotatedDirectionX][2 + TempRotatedDirectionY]);
+                        CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromAnimationSet(OldAnimationSet, config).MovesetArray[2 + TempRotatedDirectionX][2 + TempRotatedDirectionY]);
                     }
                     bShouldUseTrueLocationOrientation = true;
                     CurrentAnimationRequest.bShouldTeleportToLocation = true;
@@ -867,7 +867,7 @@ public class CustomMovementHandler
             else if (bCurrentlyWooxWalking && config.AllowWooxWalkDetection() && bIsDefaultHumanAnimationSet)
             {
                 // Handle woox walking
-                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.GetAnimationRequestMovesetFromUniqueKey(OldAnimationSet,"WooxWalk", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,"WooxWalk", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
 
                 // No turning if no target
                 if (currentTarget == null)
@@ -883,7 +883,7 @@ public class CustomMovementHandler
             else if ((config.AlwaysHoppingMode() || FramesSinceIdle > config.TickPerfectMovesUntilJumping()) && bIsDefaultHumanAnimationSet)
             {
                 // Handle tick perfect moving
-                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.GetAnimationRequestMovesetFromUniqueKey(OldAnimationSet,"TickPerfectMovement", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,"TickPerfectMovement", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
             }
             else
             {
@@ -891,12 +891,12 @@ public class CustomMovementHandler
                 if (bSpecialMoveAnimation && bIsDefaultHumanAnimationSet)
                 {
                     // Handle normal walking
-                    CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.GetAnimationRequestMovesetFromUniqueKey(OldAnimationSet,"SpecialMoves", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                    CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,"SpecialMoves", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
                 }
                 else
                 {
                     // Handle normal walking
-                    CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.GetAnimationRequestMovesetFromAnimationSet(OldAnimationSet, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                    CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromAnimationSet(OldAnimationSet, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
                 }
             }
         }


### PR DESCRIPTION
Improvements that focus on the moveset cache.
- Make the HashMap cache private and final to encapsulate.
- Using computeIfAbsent on the HashMap to ensure atomicity.
- GetAnimationRequestMovesetFromAnimationSet is renamed to getMovesetFromAnimationSet for conciseness and camelcase naming.
- Behaviour has not been changed. Noted there is still the bug in TODO in the updated method.