### PR TITLE
Introduce SpecialAnimationPreset Enum

### DIFF
--- a/src/main/java/com/truetileanimationmovement/AnimationRequestMoveset.java
+++ b/src/main/java/com/truetileanimationmovement/AnimationRequestMoveset.java
@@ -3,6 +3,7 @@ package com.truetileanimationmovement;
 import java.lang.reflect.Array;
 
 import net.runelite.api.gameval.AnimationID;
+import com.truetileanimationmovement.movement.SpecialAnimationPreset;
 
 public class AnimationRequestMoveset
 {
@@ -191,8 +192,12 @@ public class AnimationRequestMoveset
         return NewRequest;
     }
 
-    public void ConstructFromSpecialAnimationSet(IdleAnimationSet AnimSet, String SpecialAnimationKey, TrueTileMovementConfig config) {
-        if (SpecialAnimationKey.equals("SpecialMoves")) {
+    public void ConstructFromSpecialAnimationSet(
+            final IdleAnimationSet AnimSet,
+            final SpecialAnimationPreset preset,
+            final TrueTileMovementConfig config)
+    {
+        if (preset == SpecialAnimationPreset.SPECIAL_MOVES) {
             for (int i = 0; i < 5; ++i) {
                 for (int j = 0; j < 5; ++j) {
                     MovesetArray[i][j] = GetDefaultSpecialMoveAnimationRequest();
@@ -392,7 +397,8 @@ public class AnimationRequestMoveset
             NORTHWEST_2.StartingFrame = 0;
             NORTHWEST_2.bAllowAnimationLoop = false;
         }
-        else if (SpecialAnimationKey.equals("WooxWalk"))
+        else if (preset == SpecialAnimationPreset.WOOX_WALK ||
+                preset == SpecialAnimationPreset.TICK_PERFECT_MOVEMENT)
         {
             for (int i = 0; i < 5; ++i)
             {
@@ -426,42 +432,6 @@ public class AnimationRequestMoveset
                 }
             }
             Initialize();
-        }
-        else if (SpecialAnimationKey.equals("TickPerfectMovement"))
-        {
-            for (int i = 0; i < 5; ++i)
-            {
-                for (int j = 0; j < 5; ++j)
-                {
-                    MovesetArray[i][j] = GetDefaultSpecialMoveAnimationRequest();
-
-                    // 2 Tiles
-                    if (i == 0 || j == 0 || i == 4 || j == 4)
-                    {
-                        MovesetArray[i][j].bResetAnimationOnNewTile = true;
-                        MovesetArray[i][j].AnimationToPlay = AnimationID.HUMAN_JUMP_STONES; // 1604
-                        MovesetArray[i][j].bUseLinearTween = false;
-                        MovesetArray[i][j].MovementSpeedMultiplier = 1.5;
-                        MovesetArray[i][j].AnimationSpeed = 1;
-                        MovesetArray[i][j].StartingFrame = 2;
-                        MovesetArray[i][j].EndingFrame = 7;
-                        MovesetArray[i][j].bAllowAnimationLoop = false;
-                    }
-                    // 1 Tile
-                    else if (i == 1 || j == 1 || i == 3 || j == 3)
-                    {
-                        MovesetArray[i][j].AnimationToPlay = AnimationID.HUMAN_SPOT_JUMP; // Little jump. 741
-                        MovesetArray[i][j].MovementSpeedMultiplier = 2.0;
-                        MovesetArray[i][j].bUseLinearTween = false;
-                        MovesetArray[i][j].StartingFrame = 2;
-                        MovesetArray[i][j].AnimationSpeed = 1;
-                        MovesetArray[i][j].EndingFrame = 7;
-                        MovesetArray[i][j].bAllowAnimationLoop = false;
-                    }
-                }
-            }
-            Initialize();
-
         }
     }
 

--- a/src/main/java/com/truetileanimationmovement/AnimationRequestMovesetCache.java
+++ b/src/main/java/com/truetileanimationmovement/AnimationRequestMovesetCache.java
@@ -1,5 +1,7 @@
 package com.truetileanimationmovement;
 
+import com.truetileanimationmovement.movement.SpecialAnimationPreset;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,19 +16,20 @@ public class AnimationRequestMovesetCache
 
     public static AnimationRequestMoveset getMovesetFromUniqueKey(
             final IdleAnimationSet animSet,
-            final String uniqueLabel,
+            final SpecialAnimationPreset preset,
             final TrueTileMovementConfig config)
     {
         // TODO: BUG->Config not effecting Label, so changes to the config does not update this
-        return NAME_TO_MOVESET_REQUEST.computeIfAbsent(uniqueLabel, key ->
-        {
-            final AnimationRequestMoveset newMoveset =
-                    new AnimationRequestMoveset();
-            newMoveset.Initialize();
-            newMoveset.ConstructFromSpecialAnimationSet(
-                    animSet, uniqueLabel, config);
-            return newMoveset;
-        });
+        return NAME_TO_MOVESET_REQUEST.computeIfAbsent(preset.getUniqueLabel(),
+                key ->
+                {
+                    final AnimationRequestMoveset newMoveset =
+                            new AnimationRequestMoveset();
+                    newMoveset.Initialize();
+                    newMoveset.ConstructFromSpecialAnimationSet(
+                            animSet, preset, config);
+                    return newMoveset;
+                });
     }
 
     public static AnimationRequestMoveset getMovesetFromAnimationSet(

--- a/src/main/java/com/truetileanimationmovement/CustomMovementHandler.java
+++ b/src/main/java/com/truetileanimationmovement/CustomMovementHandler.java
@@ -1,5 +1,6 @@
 package com.truetileanimationmovement;
 
+import com.truetileanimationmovement.movement.SpecialAnimationPreset;
 import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
@@ -879,7 +880,7 @@ public class CustomMovementHandler
             else if (bCurrentlyWooxWalking && config.AllowWooxWalkDetection() && bIsDefaultHumanAnimationSet)
             {
                 // Handle woox walking
-                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,"WooxWalk", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,SpecialAnimationPreset.WOOX_WALK, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
 
                 // No turning if no target
                 if (currentTarget == null)
@@ -895,7 +896,7 @@ public class CustomMovementHandler
             else if ((config.AlwaysHoppingMode() || FramesSinceIdle > config.TickPerfectMovesUntilJumping()) && bIsDefaultHumanAnimationSet)
             {
                 // Handle tick perfect moving
-                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,"TickPerfectMovement", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,SpecialAnimationPreset.TICK_PERFECT_MOVEMENT, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
             }
             else
             {
@@ -903,7 +904,7 @@ public class CustomMovementHandler
                 if (bSpecialMoveAnimation && bIsDefaultHumanAnimationSet)
                 {
                     // Handle normal walking
-                    CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,"SpecialMoves", config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
+                    CurrentAnimationRequest = AnimationRequestDetails.NewObject(AnimationRequestMovesetCache.getMovesetFromUniqueKey(OldAnimationSet,SpecialAnimationPreset.SPECIAL_MOVES, config).MovesetArray[2 + RotatedDirectionX][2 + RotatedDirectionY]);
                 }
                 else
                 {

--- a/src/main/java/com/truetileanimationmovement/movement/SpecialAnimationPreset.java
+++ b/src/main/java/com/truetileanimationmovement/movement/SpecialAnimationPreset.java
@@ -1,0 +1,67 @@
+package com.truetileanimationmovement.movement;
+
+import lombok.ToString;
+
+/**
+ * Defines the set of special animation presets that can override the default
+ * walk/run animations during movement.
+ * <p>
+ * Each preset represents a distinct movement behaviour with its own tailored
+ * animation moveset. Presets are intended to be looked up and cached by their
+ * {@link #getUniqueLabel() unique label}.
+ */
+@ToString
+public enum SpecialAnimationPreset
+{
+    /**
+     * A preset for visually expressive combat-oriented movement animations.
+     * <p>
+     * Each direction in the moveset grid is assigned a unique flavour animation
+     * (e.g. spin moves, side-steps, knockbacks, jumps) tuned to the relative
+     * direction and distance of travel.
+     */
+    SPECIAL_MOVES("SpecialMoves"),
+
+    /**
+     * A preset representing the <a
+     * href="https://oldschool.runescape.wiki/w/Vorkath/Strategies#The_Woox_Walk">
+     * Woox Walk</a> animation sequence.
+     * <p>
+     * Activates when the player is detected as Woox Walking: alternating
+     * between attacking and moving on every game tick to avoid boss
+     * mechanics. The moveset uses small hops for 1-tile moves and larger jumps
+     * for 2-tile moves to reflect the rapid, snappy nature of this technique.
+     */
+    WOOX_WALK("WooxWalk"),
+
+    /**
+     * A preset for tick-perfect continuous movement, where the player moves
+     * every game tick without pausing.
+     * <p>
+     * Activates when the player has been moving for more consecutive ticks than
+     * the configured {@code TickPerfectMovesUntilJumping} threshold, or when
+     * {@code AlwaysHoppingMode} is enabled. Uses the same jump-based moveset as
+     * {@link #WOOX_WALK}: small hops for 1-tile moves and larger jumps for
+     * 2-tile moves, to convey the fast, precise cadence of tick-perfect
+     * pathing.
+     */
+    TICK_PERFECT_MOVEMENT("TickPerfectMovement");
+
+    private final String uniqueLabel;
+
+    SpecialAnimationPreset(final String uniqueLabel)
+    {
+        this.uniqueLabel = uniqueLabel;
+    }
+
+    /**
+     * Returns the unique string label used to identify and cache the moveset
+     * for this preset in {@code String} based key caches.
+     *
+     * @return the unique label for this preset
+     */
+    public String getUniqueLabel()
+    {
+        return uniqueLabel;
+    }
+}


### PR DESCRIPTION
The enum is designed to be make special movesets typesafe. The enum defines all three special movements: Woox walk, tick perfect, and special moves. A unique label property is available on the enum to maintain the String-based key on the moveset cache.

Relevant method calls on AnimationRequestMoveset, AnimationRequestMovementCache, and CustomMovementHandler have been amended to use the enum. The String value is only used for caching.

In AnimationRequestMoveset#ConstructFromSpecialAnimationSet method there is a complete identical branch for WooxWalk and TickPerfectMovement. This has been refactored into one branch. If it's desired to diverge in behaviour in the future, this can be resplit with the desired behaviour.